### PR TITLE
Update stl error check

### DIFF
--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stl-api/express",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "license": "ISC",
   "description": "express integration for stainless api",
   "author": "dev@stainlessapi.com",

--- a/packages/express/src/index.ts
+++ b/packages/express/src/index.ts
@@ -10,13 +10,13 @@ import express, {
   RouterOptions,
 } from "express";
 import {
-  StlError,
   AnyAPIDescription,
   AnyActionsConfig,
   EndpointResponseOutput,
   StlContext,
   RequestData,
   EndpointResponseInput,
+  isStlError,
 } from "stainless";
 import { parseEndpoint, type AnyEndpoint } from "stainless";
 
@@ -202,7 +202,7 @@ const errorHandler: ErrorRequestHandler = (
   req: Request,
   res: Response
 ) => {
-  if (error instanceof StlError) {
+  if (isStlError(error)) {
     res.status(error.statusCode).json(error.response);
     return;
   }

--- a/packages/next-auth/package.json
+++ b/packages/next-auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stl-api/next-auth",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "next-auth plugin for stainless api",
   "author": "dev@stainlessapi.com",
   "repository": {

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stl-api/next",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "license": "ISC",
   "description": "next.js plugin for stainless api",
   "author": "dev@stainlessapi.com",

--- a/packages/next/src/nextPlugin.ts
+++ b/packages/next/src/nextPlugin.ts
@@ -1,11 +1,10 @@
 import {
   AnyAPIDescription,
   AnyEndpoint,
-  AnyBaseEndpoint,
   MakeStainlessPlugin,
   NotFoundError,
-  StlError,
   allEndpoints,
+  isStlError,
 } from "stainless";
 import qs from "qs";
 import { NextApiRequest, NextApiResponse } from "next";
@@ -162,7 +161,7 @@ function makeRouter(
       const result = await stl.execute(params, context);
       return NextResponse.json(result);
     } catch (error) {
-      if (error instanceof StlError) {
+      if (isStlError(error)) {
         return NextResponse.json(error.response, {
           status: error.statusCode,
         });
@@ -239,7 +238,7 @@ function makeRouter(
       const result = await stl.execute(params, context);
       res.status(200).send(result);
     } catch (error) {
-      if (error instanceof StlError) {
+      if (isStlError(error)) {
         res.status(error.statusCode).json(error.response);
         return;
       }

--- a/packages/stainless/package.json
+++ b/packages/stainless/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stainless",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "stainless api server and client",
   "author": "dev@stainlessapi.com",
   "repository": {

--- a/packages/stainless/src/stl.ts
+++ b/packages/stainless/src/stl.ts
@@ -295,6 +295,10 @@ export type RouteMapAction = {
 
 export type AnyAPIDescription = APIDescription<any, any, any>;
 
+export const isStlError = (value: unknown): value is StlError => {
+  return value instanceof StlError || (value as any)?._isStlError === true;
+};
+
 /**
  * Throw `StlError` and its subclasses within endpoint `handler` methods
  * to return 4xx or 5xx HTTP error responses to the user, with well-formatted
@@ -304,6 +308,8 @@ export type AnyAPIDescription = APIDescription<any, any, any>;
  * codes we don't yet provide out of the box.
  */
 export class StlError extends Error {
+  _isStlError = true;
+
   /**
    * @param statusCode
    * @param response optional data included in the body of the response JSON.


### PR DESCRIPTION
The existing `instanceof` check doesn't work in cases where the `stainless` package is used alongside one of the plugins (e.g. `next`), in which case the `StlError` could be imported more than once (i.e. they would actually be different classes). 

Fixes STA-3208