### PR TITLE
Fix github deps to work with Bun

### DIFF
--- a/packages/stainless/package.json
+++ b/packages/stainless/package.json
@@ -51,6 +51,6 @@
     "qs": "^6.11.2",
     "ts-node": "^10.9.1",
     "zod": "^3.22.4",
-    "zod-openapi": "github:stainless-api/zod-openapi#2.8.0"
+    "zod-openapi": "git+ssh://github.com/stainless-api/zod-openapi#2.8.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -504,7 +504,7 @@ importers:
         specifier: ^3.22.4
         version: 3.22.4
       zod-openapi:
-        specifier: github:stainless-api/zod-openapi#2.8.0
+        specifier: git+ssh://github.com/stainless-api/zod-openapi#2.8.0
         version: github.com/stainless-api/zod-openapi/550978836406882613e9547b2e9486fa7448a37b(zod@3.22.4)
     devDependencies:
       '@types/jest':

--- a/scripts/setDependencyVersions.mjs
+++ b/scripts/setDependencyVersions.mjs
@@ -9,7 +9,7 @@ import { isMainModule } from "./isMainModule.mjs";
 
 /**
  * This updates monorepo packages like "@stl-api/next": "workspace:*" to
- * "@stl-api/next": "github:stainless-api/stl-api#next-0.0.3". Once we're
+ * "@stl-api/next": "git+ssh://github.com/stainless-api/stl-api#next-0.0.3". Once we're
  * ready to publish to npm, we can get rid of this and use `pnpm publish`
  * instead.
  */
@@ -45,7 +45,9 @@ export async function setDependencyVersions() {
     for (const pkg in dependencies) {
       const depPackageJson = packageJsonsByName[pkg];
       if (depPackageJson) {
-        dependencies[pkg] = `github:${owner}/${repo}#${pkg.replace(
+        dependencies[
+          pkg
+        ] = `git+ssh://github.com/${owner}/${repo}#${pkg.replace(
           /^@stl-api\//,
           ""
         )}-${depPackageJson.version}`;


### PR DESCRIPTION
[Bun](https://bun.sh) doesn't support a `#git-branch` when using the `github:` format, resulting in `error: zod-openapi@github:stainless-api/zod-openapi#2.8.0 failed to resolve` when importing `stl-api/stainless`. Instead we can use the `git+ssh`.

Confirmed to work with `pnpm i`, `bun i`, and `npm i`.