### PR TITLE
Correctly kebabCase numbers

### DIFF
--- a/packages/client/src/util/strings.test.ts
+++ b/packages/client/src/util/strings.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from "vitest";
+import { kebabCase } from "./strings";
+
+describe("kebabCase", () => {
+  test("Basic", () => {
+    expect(kebabCase("myPathName")).toBe("my-path-name");
+  });
+
+  test("Numbers", () => {
+    expect(kebabCase("v0")).toBe("v0");
+    expect(kebabCase("version123Path")).toBe("version123-path");
+  });
+});

--- a/packages/client/src/util/strings.ts
+++ b/packages/client/src/util/strings.ts
@@ -28,9 +28,9 @@ export function kebabCase(str: string) {
   return str
     .split("")
     .map((letter, idx) => {
-      return letter.toUpperCase() === letter
-        ? `${idx !== 0 ? "-" : ""}${letter.toLowerCase()}`
-        : letter;
+      return letter.toLowerCase() === letter
+        ? letter
+        : `${idx !== 0 ? "-" : ""}${letter.toLowerCase()}`;
     })
     .join("");
 }


### PR DESCRIPTION
camelCase and kebabCase need to be exact inverses, otherwise API clients fail. `camelCase('v0') === 'v0'`, so we need to ensure that kebalCase does the same.

This makes non-alpha chars not start a new word.