### PR TITLE
fix: replace Identifier type when not surrounded by spaces

### DIFF
--- a/packages/client/src/codegen/generate-types.ts
+++ b/packages/client/src/codegen/generate-types.ts
@@ -148,8 +148,8 @@ function nestEndpoints(
 function zodToString(schema: ZodTypeAny) {
   const { node } = zodToTs(schema, undefined, { nativeEnums: "union" });
   const nodeString = printNode(node);
-  // This happens with large, lazyily loaded zod types
-  return nodeString.replaceAll(" Identifier ", " unknown ");
+  // This happens with large, lazily loaded zod types
+  return nodeString.replace(/\bIdentifier\b/g, "unknown");
 }
 
 function makeParameterType(


### PR DESCRIPTION
### Summary
`replaceAll(" Identifier ", " unknown ")` doesn't work for stuff like `Promise<Identifier>`.

Using regex and matching for word boundaries instead of spaces replaces `Promise<Identifier>`, but not `IdentifierType`, for example.

### Test plan
Built and installed locally, verified that the change fixes the issues with generating the v0 API client.
<img width="1164" height="403" alt="image" src="https://github.com/user-attachments/assets/5b242839-4111-4dff-9e65-eaf0293ee5ca" />