### PR TITLE
fix(hono): return 204 for void handler results instead of crashing

### DIFF
--- a/packages/hono/package.json
+++ b/packages/hono/package.json
@@ -34,7 +34,7 @@
     "typescript": "^5.3.2"
   },
   "dependencies": {
-    "hono": "^4.0.0",
+    "hono": "^4.12.1",
     "qs": "^6.11.2",
     "stainless": "workspace:*"
   }

--- a/packages/hono/src/__tests__/honoPlugin.test.ts
+++ b/packages/hono/src/__tests__/honoPlugin.test.ts
@@ -4,6 +4,50 @@ import { stlApi } from "../honoPlugin";
 
 const stl = new Stl({ plugins: {} });
 
+describe("void-returning handlers", () => {
+  const api = stl.api({
+    basePath: "/api",
+    resources: {
+      webhooks: stl.resource({
+        summary: "webhooks",
+        actions: {
+          fireAndForget: stl.endpoint({
+            endpoint: "POST /api/webhooks/events",
+            handler: async () => {
+              // Handler that does work but returns nothing
+            },
+          }),
+          earlyReturn: stl.endpoint({
+            endpoint: "POST /api/webhooks/noop",
+            handler: async () => {
+              return;
+            },
+          }),
+        },
+      }),
+    },
+  });
+
+  const app = new Hono();
+  app.use("*", stlApi(api));
+
+  test("handler returning void responds with 204", async () => {
+    const response = await app.request("/api/webhooks/events", {
+      method: "POST",
+    });
+    expect(response.status).toBe(204);
+    expect(await response.text()).toBe("");
+  });
+
+  test("handler with explicit bare return responds with 204", async () => {
+    const response = await app.request("/api/webhooks/noop", {
+      method: "POST",
+    });
+    expect(response.status).toBe(204);
+    expect(await response.text()).toBe("");
+  });
+});
+
 describe("basic routing", () => {
   const api = stl.api({
     basePath: "/api",

--- a/packages/hono/src/honoPlugin.ts
+++ b/packages/hono/src/honoPlugin.ts
@@ -1,6 +1,6 @@
 import { Context } from "hono";
 import { createMiddleware } from "hono/factory";
-import { StatusCode } from "hono/utils/http-status";
+import { ContentfulStatusCode } from "hono/utils/http-status";
 import qs from "qs";
 import {
   allEndpoints,
@@ -91,6 +91,10 @@ function makeHandler(endpoints: AnyEndpoint[], options?: StlAppOptions) {
         return result;
       }
 
+      if (result === undefined) {
+        return c.body(null, 204);
+      }
+
       return c.json(result);
     } catch (error) {
       if (options?.handleErrors === false) {
@@ -98,7 +102,7 @@ function makeHandler(endpoints: AnyEndpoint[], options?: StlAppOptions) {
       }
 
       if (isStlError(error)) {
-        return c.json(error.response, error.statusCode as StatusCode);
+        return c.json(error.response, error.statusCode as ContentfulStatusCode);
       }
 
       console.error(

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -31,7 +31,7 @@
     "next": "^14.2.8"
   },
   "dependencies": {
-    "hono": "^4.0.0",
+    "hono": "^4.12.0",
     "lodash": "^4.17.21",
     "qs": "^6.11.2",
     "stainless": "workspace:*"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -384,8 +384,8 @@ importers:
   packages/hono:
     dependencies:
       hono:
-        specifier: ^4.0.0
-        version: 4.6.1
+        specifier: ^4.12.1
+        version: 4.12.2
       qs:
         specifier: ^6.11.2
         version: 6.13.0
@@ -415,8 +415,8 @@ importers:
   packages/next:
     dependencies:
       hono:
-        specifier: ^4.0.0
-        version: 4.6.1
+        specifier: ^4.12.0
+        version: 4.12.2
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
@@ -4268,9 +4268,9 @@ packages:
   hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
 
-  hono@4.6.1:
-    resolution: {integrity: sha512-6NGwvttY1+HAFii08VYiEKI6ETPAFbpLntpm2M/MogEsAFWdZV74UNT+2M4bmqX90cIQhjlpBSP+tO+CfB0uww==}
-    engines: {node: '>=16.0.0'}
+  hono@4.12.2:
+    resolution: {integrity: sha512-gJnaDHXKDayjt8ue0n8Gs0A007yKXj4Xzb8+cNjZeYsSzzwKc0Lr+OZgYwVfB0pHfUs17EPoLvrOsEaJ9mj+Tg==}
+    engines: {node: '>=16.9.0'}
 
   hpack.js@2.1.6:
     resolution: {integrity: sha512-zJxVehUdMGIKsRaNt7apO2Gqp0BdqW5yaiGHXXmbpvxgBYVZnAql+BJb4RO5ad2MgpbZKn5G6nMnegrH1FcNYQ==}
@@ -12505,7 +12505,7 @@ snapshots:
     dependencies:
       react-is: 16.13.1
 
-  hono@4.6.1: {}
+  hono@4.12.2: {}
 
   hpack.js@2.1.6:
     dependencies:


### PR DESCRIPTION
Hono 4.12.1 added a fast path in `Context.json()` that uses the static `Response.json()` method. Unlike the previous `JSON.stringify()` + `new Response()` path, `Response.json(undefined)` throws `TypeError: Value is not JSON serializable`.

Any stl endpoint handler that returns void (e.g. webhook handlers that do work but have no meaningful response) hits `c.json(undefined)` in the plugin and crashes with a 500 in production on Hono >= 4.12.

Return a 204 No Content when the handler result is `undefined`, which is the correct HTTP semantic for "request succeeded, no body".

It's fixed in hono 4.12.2 as far as I can tell