### PR TITLE
fix(openapi): handle ZodVoid responses as 204 No Content

### DIFF
--- a/packages/stainless/src/openapiSpec.ts
+++ b/packages/stainless/src/openapiSpec.ts
@@ -61,18 +61,21 @@ export async function openapiSpec(
           },
         },
       },
-      responses: {
-        200: {
-          description: "success",
-          content: route.response
-            ? {
-                "application/json": {
-                  schema: route.response,
-                },
-              }
-            : {},
-        },
-      },
+      responses:
+        route.response instanceof z.ZodVoid
+          ? { 204: { description: "No content" } }
+          : {
+              200: {
+                description: "success",
+                content: route.response
+                  ? {
+                      "application/json": {
+                        schema: route.response,
+                      },
+                    }
+                  : {},
+              },
+            },
     };
 
     paths[path] ??= {};


### PR DESCRIPTION
This was causing 500s.

## Context

This avoids crashes for these endpoints:

- `DELETE /api/account/device-connections/{connectionId}`
- `DELETE /api/orgs/{orgName}/postman-credentials`
- `DELETE /api/orgs/{orgName}/vcs-app`
- `DELETE /api/orgs/{orgName}/projects/{projectName}`
- `DELETE /api/orgs/{orgName}/pending-projects/{projectName}`
- `DELETE /api/orgs/{orgName}/projects/{projectName}/sdk-requests`
- `DELETE /api/orgs/{orgName}/projects/{projectName}/sdks/{language}`
- `DELETE /api/docs-sites/{docsSiteId}/domains/{domainId}`
- `DELETE /api/users/{userId}/tutorial-modals/{modalType}`